### PR TITLE
perf: reuse depSubs checkDirty

### DIFF
--- a/lib/src/system.dart
+++ b/lib/src/system.dart
@@ -310,7 +310,7 @@ bool checkDirty(Link? deps) {
         } else if ((depFlags & SubscriberFlags.toCheckDirty) != 0) {
           final depSubs = dep.subs!;
           if (depSubs.nextSub != null) {
-            dep.subs!.prevSub = deps;
+            depSubs.prevSub = deps;
           }
           deps = dep.deps;
           ++stack;


### PR DESCRIPTION
Remove unnecessary subs property operations. (A regression in #4)