### PR TITLE
Upstream 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.4.1
+
+- refactor: simplifying unlink sub in effect cleanup
+- refactor: update pauseTracking and resumeTracking to use setCurrentSub
+- refactor(preset): change queuedEffects to map like JS Array
+- refactor: remove generic type from effect, effectScope
+- refactor: more accurate unwatched handling
+- fix: invalidate parent effect when executing effectScope
+- test: update untrack tests
+- test: use setCurrentSub instead of pauseTracking
+
+**NOTE**: Sync upstream v2.0.4 version.
+
 ## v0.4.0
 
 ### Major Changes

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -89,7 +89,7 @@ final link = system.link,
     shallowPropagate = system.shallowPropagate;
 
 final pauseStack = <ReactiveNode?>[];
-final queuedEffects = <ReactiveNode?>[];
+final queuedEffects = <int, ReactiveNode?>{};
 
 int batchDepth = 0;
 int notifyIndex = 0;
@@ -193,18 +193,7 @@ void notifyEffect(ReactiveNode e) {
     if (subs != null) {
       notifyEffect(subs.sub);
     } else {
-      // queuedEffects[queuedEffectsLength++] = e;
-      //
-      // NOTE: Dart not support dynamic using index,
-      // so, we will fill null items.
-
-      final nextIndex = queuedEffectsLength + 1;
-      if (queuedEffects.length < nextIndex) {
-        queuedEffects.length = nextIndex;
-      }
-
-      queuedEffects[queuedEffectsLength] = e;
-      queuedEffectsLength = nextIndex;
+      queuedEffects[queuedEffectsLength++] = e;
     }
   }
 }

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -62,13 +62,17 @@ class PresetReactiveSystsm extends ReactiveSystem {
   void notify(ReactiveNode sub) => notifyEffect(sub);
 
   @override
-  void unwatched(ReactiveNode sub) {
-    var toRemove = sub.deps;
-    if (toRemove != null) {
-      do {
-        toRemove = unlink(toRemove!, sub);
-      } while (toRemove != null);
-      sub.flags |= ReactiveFlags.dirty;
+  void unwatched(ReactiveNode node) {
+    if (node is Computed) {
+      var toRemove = node.deps;
+      if (toRemove != null) {
+        node.flags = ReactiveFlags.mutable | ReactiveFlags.dirty;
+        do {
+          toRemove = unlink(toRemove!, node);
+        } while (toRemove != null);
+      }
+    } else if (node is! Signal) {
+      effectOper(node);
     }
   }
 

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -116,16 +116,17 @@ void endBatch() {
   if ((--batchDepth) == 0) flush();
 }
 
+@Deprecated("TODO: Remove in next major")
 void pauseTracking() {
-  pauseStack.add(activeSub);
-  activeSub = null;
+  pauseStack.add(setCurrentSub(null));
 }
 
+@Deprecated("TODO: Remove in next major")
 void resumeTracking() {
   try {
-    activeSub = pauseStack.removeLast();
+    setCurrentSub(pauseStack.removeLast());
   } catch (_) {
-    activeSub = null;
+    setCurrentSub(null);
   }
 }
 

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -116,12 +116,15 @@ void endBatch() {
   if ((--batchDepth) == 0) flush();
 }
 
-@Deprecated("TODO: Remove in next major")
+@Deprecated("Will be removed in the next major version. Use"
+    "`const pausedSub = setCurrentSub(null)`"
+    " instead for better performance.")
 void pauseTracking() {
   pauseStack.add(setCurrentSub(null));
 }
 
-@Deprecated("TODO: Remove in next major")
+@Deprecated(
+    "Will be removed in the next major version. Use `setCurrentSub(pausedSub)` instead for better performance.")
 void resumeTracking() {
   try {
     setCurrentSub(pauseStack.removeLast());

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -8,10 +8,10 @@ class EffectScope extends ReactiveNode {
   EffectScope({required super.flags});
 }
 
-class Effect<T> extends ReactiveNode {
+class Effect extends ReactiveNode {
   Effect({required super.flags, required this.run});
 
-  final T Function() run;
+  final void Function() run;
 }
 
 abstract interface class Updatable {
@@ -151,7 +151,7 @@ T Function() computed<T>(T Function(T? previousValue) getter) {
   return () => computedOper(computed);
 }
 
-void Function() effect<T>(T Function() run) {
+void Function() effect(void Function() run) {
   final e = Effect(run: run, flags: ReactiveFlags.watching);
   if (activeSub != null) {
     link(e, activeSub!);
@@ -168,7 +168,7 @@ void Function() effect<T>(T Function() run) {
   return () => effectOper(e);
 }
 
-void Function() effectScope<T>(T Function() run) {
+void Function() effectScope(void Function() run) {
   final e = EffectScope(flags: ReactiveFlags.none);
   if (activeScope != null) link(e, activeScope!);
 

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -168,11 +168,15 @@ void Function() effect<T>(T Function() run) {
 void Function() effectScope<T>(T Function() run) {
   final e = EffectScope(flags: ReactiveFlags.none);
   if (activeScope != null) link(e, activeScope!);
-  final prev = setCurrentScope(e);
+
+  final prevSub = setCurrentSub(null);
+  final prevScope = setCurrentScope(e);
+
   try {
     run();
   } finally {
-    activeScope = prev;
+    setCurrentScope(prevScope);
+    setCurrentSub(prevSub);
   }
 
   return () => effectOper(e);

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -297,11 +297,8 @@ void effectOper(ReactiveNode e) {
     dep = unlink(dep, e);
   }
 
-  var sub = e.subs;
-  while (sub != null) {
-    unlink(sub);
-    sub = e.subs;
-  }
+  final sub = e.subs;
+  if (sub != null) unlink(sub);
 
   e.flags = ReactiveFlags.none;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alien_signals
 description: The lightest signal library - Dart implementation of alien-signals.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/medz/alien-signals-dart
 
 topics:

--- a/test/effect_scope_test.dart
+++ b/test/effect_scope_test.dart
@@ -22,4 +22,26 @@ void main() {
     count(4);
     expect(triggers, 3);
   });
+
+  test("should dispose inner effects if created in an effect", () {
+    final s = signal(1);
+    int triggers = 0;
+
+    effect(() {
+      final dispose = effectScope(() {
+        effect(() {
+          s();
+          triggers++;
+        });
+      });
+      expect(triggers, 1);
+
+      s(2);
+      expect(triggers, 2);
+
+      dispose();
+      s(3);
+      expect(triggers, 2);
+    });
+  });
 }

--- a/test/effect_test.dart
+++ b/test/effect_test.dart
@@ -167,9 +167,9 @@ void main() {
 
     effect(() {
       order.add("a");
-      pauseTracking();
+      final currentSub = setCurrentSub(null);
       final isOne = s2() == 1;
-      resumeTracking();
+      setCurrentSub(currentSub);
       if (isOne) s1();
       s2();
       s1();

--- a/test/untrack_test.dart
+++ b/test/untrack_test.dart
@@ -8,11 +8,11 @@ void main() {
 
     final c = computed((_) {
       computedTriggerTimes++;
-      pauseTracking();
+      final currentSub = setCurrentSub(null);
       try {
         return s();
       } finally {
-        resumeTracking();
+        setCurrentSub(currentSub);
       }
     });
 
@@ -34,9 +34,9 @@ void main() {
     effect(() {
       effectTriggerTimes++;
       if (b() > 0) {
-        pauseTracking();
+        final currentSub = setCurrentSub(null);
         a();
-        resumeTracking();
+        setCurrentSub(currentSub);
       }
     });
 
@@ -73,9 +73,9 @@ void main() {
     effectScope(() {
       effect(() {
         effectTriggerTimes++;
-        pauseTracking();
+        final currentSub = setCurrentSub(null);
         s();
-        resumeTracking();
+        setCurrentSub(currentSub);
       });
     });
 

--- a/test/untrack_test.dart
+++ b/test/untrack_test.dart
@@ -2,9 +2,12 @@ import 'package:alien_signals/alien_signals.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("should pause tracking", () {
+  test("should pause tracking in computed", () {
     final s = signal(0);
+    int computedTriggerTimes = 0;
+
     final c = computed((_) {
+      computedTriggerTimes++;
       pauseTracking();
       try {
         return s();
@@ -14,8 +17,73 @@ void main() {
     });
 
     expect(c(), 0);
+    expect(computedTriggerTimes, 1);
 
     s(1);
+    s(2);
+    s(3);
     expect(c(), 0);
+    expect(computedTriggerTimes, 1);
+  });
+
+  test("should pause tracking in effect", () {
+    final a = signal(0);
+    final b = signal(0);
+
+    int effectTriggerTimes = 0;
+    effect(() {
+      effectTriggerTimes++;
+      if (b() > 0) {
+        pauseTracking();
+        a();
+        resumeTracking();
+      }
+    });
+
+    expect(effectTriggerTimes, 1);
+
+    b(1);
+    expect(effectTriggerTimes, 2);
+
+    a(1);
+    a(2);
+    a(3);
+    expect(effectTriggerTimes, 2);
+
+    b(2);
+    expect(effectTriggerTimes, 3);
+
+    a(4);
+    a(5);
+    a(6);
+    expect(effectTriggerTimes, 3);
+
+    b(0);
+    expect(effectTriggerTimes, 4);
+
+    a(7);
+    a(8);
+    a(9);
+    expect(effectTriggerTimes, 4);
+  });
+
+  test("should pause tracking in effect scope", () {
+    final s = signal(0);
+    int effectTriggerTimes = 0;
+    effectScope(() {
+      effect(() {
+        effectTriggerTimes++;
+        pauseTracking();
+        s();
+        resumeTracking();
+      });
+    });
+
+    expect(effectTriggerTimes, 1);
+
+    s(1);
+    s(2);
+    s(3);
+    expect(effectTriggerTimes, 1);
   });
 }


### PR DESCRIPTION
- refactor: simplifying unlink sub in effect cleanup
- refactor: update pauseTracking and resumeTracking to use setCurrentSub
- refactor(preset): change queuedEffects to map like JS Array
- refactor: remove generic type from effect, effectScope
- refactor: more accurate unwatched handling
- fix: invalidate parent effect when executing effectScope
- test: update untrack tests
- test: use setCurrentSub instead of pauseTracking