### PR TITLE
release 1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        sdk: [stable, 3.6, 3.7]
+        sdk: [stable, 3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,37 @@ name: testing
 on: [push, pull_request]
 
 jobs:
-  run:
+  analyze:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: latest
+      - run: dart pub get
+      - run: dart analyze
 
+  test:
+    needs: analyze
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         sdk: [stable, 3.6, 3.7, 3.8]
-
     steps:
       - uses: actions/checkout@v5
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.sdk }}
       - run: dart pub get
-      - run: dart analyze
       - run: dart test
+
+  try-publish:
+    needs: [analyze, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: latest
+      - run: dart pub get
+      - run: dart pub publish --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-beta.4
+
+Status: Released(2025-09-30)
+
+- **FIX**: remove assertion in effectOper
+
 ## 1.0.0-beta.3
 
 Status: Released(2025-09-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,59 @@
+## 1.0.0
+
+Status: Released (2025-01-15)
+
+🎉 **First Stable Release!**
+
+After months of development and multiple beta releases, we're excited to announce the first stable version of Alien Signals for Dart! This release brings a mature, high-performance reactive signal library to the Dart ecosystem.
+
+### 🚀 What's New in 1.0.0
+
+- **Stable API**: All APIs are now stable and ready for production use
+- **Better Dart Integration**: Redesigned API that feels natural in Dart
+- **Enhanced Performance**: Optimized reactive system with cycle-based dependency tracking
+- **Comprehensive Documentation**: Complete API documentation and examples
+- **Production Ready**: Battle-tested through beta releases and community feedback
+
+### 📋 Key Features
+
+- **Lightweight & Fast**: The lightest signal library for Dart with excellent performance
+- **Simple API**: Easy-to-use `signal()`, `computed()`, and `effect()` functions
+- **TypeScript Origins**: Based on the excellent [stackblitz/alien-signals](https://github.com/stackblitz/alien-signals)
+- **Effect Scopes**: Manage groups of effects with `effectScope()`
+- **Batch Updates**: Control reactivity with `startBatch()` and `endBatch()`
+
+### 🎯 Getting Started
+
+```dart
+import 'package:alien_signals/alien_signals.dart';
+
+void main() {
+  // Create a signal
+  final count = signal(0);
+
+  // Create a computed value
+  final doubled = computed((_) => count.value * 2);
+
+  // Create an effect
+  effect(() {
+    print('Count: ${count.value}, Doubled: ${doubled.value}');
+  });
+
+  // Update the signal
+  count.value++; // Prints: Count: 1, Doubled: 2
+}
+```
+
+### 🔧 Migration from Beta
+
+If you're upgrading from a beta version, please see our [Migration Guide](MIGRATION.md) for detailed instructions.
+
+### 🙏 Acknowledgments
+
+Special thanks to the StackBlitz team for creating the original alien-signals library and to our community for feedback during the beta period.
+
+---
+
 ## 1.0.0-beta.4
 
 Status: Released(2025-09-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0-beta.2
+
+Status: Released(2025-09-29)
+
+- Have good auto-imports, avoid auto-importing src
+- `Effect`/`EffectScope`'s `call()` is renamed to `dispose()`
+
 ## 1.0.0-beta.1
 
 Status: Released(2025-09-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-beta.3
+
+Status: Released(2025-09-30)
+
+- **FEATURE**: Add `preset_developer.dart`, the basics of exporting Preset
+
 ## 1.0.0-beta.2
 
 Status: Released(2025-09-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
-## 0.5.5
+## 1.0.0
 
 Status: Unreleased
+
+### System
+
+- **BREAKING CHANGE**: sync [alien-signal](https://github.com/stackblitz/alien-signals) `3.0.0` version
+- **BREAKING CHANGE**: `link` add a third version count param
+- **BREAKING CHANGE**: remove `startTracking` and `endTracking` API
+
+#### Preset
+
+- **BREAKING CHANGE**: remove deprecated `system.dart` entry point export
+- **BREAKING CHANGE**: migrate `batchDepth` to `getBatchDepth()`
+- **BREAKING CHANGE**: rename `getCurrentSub/setCurrentSub` to `getActiveSub/setActiveSub`
+- **BREAKING CHANGE**: remove `getCurrentScope/getCurrentScope`, using `getActiveScope/setActiveScope`
+- **BREAKING CHANGE**: remove signal/computed `call()`, using `.value` property
+- **FEATURE**: add `Signal`,`WritableSignal`,`Computed`,`Effect` abstract interface
+
+## 0.5.5
+
+Status: Released (2025-09-28)
 
 - Deprecate library entry point of `package:alien_signals/system.dart`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-bate.1
+## 1.0.0-beta.1
 
 Status: Released(2025-09-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 1.0.0
+## 1.0.0-bate.1
 
-Status: Unreleased
+Status: Released(2025-09-29)
 
 ### System
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,262 @@
+# Migration Guide
+
+This guide helps you migrate from earlier versions of `alien_signals` to version 1.0.0.
+
+## Migration from 0.x to 1.0.0
+
+The 1.0.0 release introduces several breaking changes to improve API consistency and performance. This guide will help you update your code.
+
+### 🔄 API Changes
+
+#### Signal Value Access
+
+**Before (0.x):**
+```dart
+final count = signal<int?>(0);
+
+// Reading value
+print(count()); // Function call syntax
+
+// Writing value
+count(1); // Function call syntax
+count(null, true); // Required second parameter for nullable values
+```
+
+**After (1.0.0):**
+```dart
+final count = signal<int?>(0);
+
+// Reading value
+print(count.value); // Property access
+
+// Writing value
+count.value = 1; // Property assignment
+count.value = null; // Direct assignment, no second parameter needed
+```
+
+#### Computed Values
+
+**Before (0.x):**
+```dart
+final doubled = computed((_) => count() * 2);
+print(doubled()); // Function call syntax
+```
+
+**After (1.0.0):**
+```dart
+final doubled = computed((_) => count.value * 2);
+print(doubled.value); // Property access
+```
+
+#### Effect and EffectScope Disposal
+
+**Before (0.x):**
+```dart
+final dispose = effect(() {
+  print(count());
+});
+dispose(); // Function call
+
+final scope = effectScope(() { /* ... */ });
+scope(); // Function call
+```
+
+**After (1.0.0):**
+```dart
+final e = effect(() {
+  print(count.value);
+});
+e.dispose(); // Method call
+
+final scope = effectScope(() { /* ... */ });
+scope.dispose(); // Method call
+```
+
+### 🏗️ System-Level Changes
+
+#### Batch Operations
+
+**Before (0.x):**
+```dart
+// Using batchDepth field
+if (batchDepth > 0) {
+  // ...
+}
+```
+
+**After (1.0.0):**
+```dart
+// Using getBatchDepth() function
+if (getBatchDepth() > 0) {
+  // ...
+}
+```
+
+#### Active Subscription Management
+
+**Before (0.x):**
+```dart
+// Old function names
+getCurrentSub();
+setCurrentSub(sub);
+
+// Removed APIs
+getCurrentScope();
+setCurrentScope(scope);
+```
+
+**After (1.0.0):**
+```dart
+// New function names
+getActiveSub();
+setActiveSub(sub);
+```
+
+#### Removed APIs
+
+The following APIs have been removed in 1.0.0:
+
+- `startTracking()` and `endTracking()` - Use inline cycle management instead
+- `pauseTracking()` and `resumeTracking()` - No direct replacement
+- `ReactiveFlags` enum - Replaced with int-based flags
+- Signal/Computed `call()` method - Use `.value` property
+
+### 📦 Import Changes
+
+#### System-Level Access
+
+**Before (0.x):**
+```dart
+import 'package:alien_signals/alien_signals.dart';
+```
+
+**After (1.0.0):**
+```dart
+import 'package:alien_signals/system.dart'; // Still available for low-level access
+```
+
+### 🛠️ Step-by-Step Migration
+
+#### 1. Update Dependencies
+
+Update your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  alien_signals: ^1.0.0
+```
+
+#### 2. Update Imports
+
+Replace deprecated imports:
+
+```dart
+// Add this
+import 'package:alien_signals/system.dart';
+```
+
+#### 3. Update Signal Usage
+
+Find and replace signal access patterns:
+
+```dart
+// Find: signalName()
+// Replace with: signalName.value
+
+// Find: signalName(newValue)
+// Replace with: signalName.value = newValue
+```
+
+#### 4. Update Effect Disposal
+
+Update effect and scope disposal:
+
+```dart
+// Find: disposeFn()
+// Replace with: disposeFn.dispose()
+
+// Find: scopeFn()
+// Replace with: scopeFn.dispose()
+```
+
+#### 5. Update System Function Calls
+
+Replace deprecated system functions:
+
+```dart
+// Find: batchDepth
+// Replace with: getBatchDepth()
+
+// Find: getCurrentSub()
+// Replace with: getActiveSub()
+
+// Find: setCurrentSub(sub)
+// Replace with: setActiveSub(sub)
+```
+
+### 🧪 Testing Your Migration
+
+After migration, ensure your code works correctly:
+
+1. **Run Tests**: Execute your existing test suite
+2. **Check Performance**: The new version should be faster
+3. **Verify Reactivity**: Ensure all signal updates trigger expected reactions
+
+### 💡 Benefits of 1.0.0
+
+After migration, you'll benefit from:
+
+- **Better Performance**: Optimized reactive system with cycle-based tracking
+- **Cleaner API**: More Dart-idiomatic property-based access
+- **Type Safety**: Better nullability handling without extra parameters
+- **Stability**: Production-ready stable API
+
+### 🔍 Common Migration Issues
+
+#### Issue: Nullable Signal Updates
+
+**Problem:**
+```dart
+// This won't work anymore
+final nullable = signal<String?>("hello");
+nullable(null); // Error: method doesn't exist
+```
+
+**Solution:**
+```dart
+final nullable = signal<String?>("hello");
+nullable.value = null; // Correct approach
+```
+
+#### Issue: Effect Disposal
+
+**Problem:**
+```dart
+final e = effect(() { /* ... */ });
+e(); // Error: not callable
+```
+
+**Solution:**
+```dart
+final e = effect(() { /* ... */ });
+e.dispose(); // Correct method call
+```
+
+### 📚 Additional Resources
+
+- [API Documentation](https://pub.dev/documentation/alien_signals/latest/)
+- [Examples](example/)
+- [GitHub Issues](https://github.com/medz/alien-signals-dart/issues)
+
+### 🆘 Need Help?
+
+If you encounter issues during migration:
+
+1. Check this guide again for common solutions
+2. Review the [API documentation](https://pub.dev/documentation/alien_signals/latest/)
+3. Open an issue on [GitHub](https://github.com/medz/alien-signals-dart/issues)
+4. Join the discussion in our community channels
+
+---
+
+**Note**: This migration guide covers the major changes from 0.x to 1.0.0. For migrations from specific beta versions, please refer to the individual changelog entries in [CHANGELOG.md](CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install Alien Signals, add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  alien_signals: 1.0
+  alien_signals: ^1.0.0
 ```
 
 Alternatively, you can run the following command:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install Alien Signals, add the following to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  alien_signals: latest
+  alien_signals: 1.0
 ```
 
 Alternatively, you can run the following command:
@@ -49,15 +49,15 @@ void main() {
   final count = signal(0);
 
   // Create a computed value
-  final doubled = computed((_) => count() * 2);
+  final doubled = computed((_) => count.value * 2);
 
   // Create an effect
   effect(() {
-    print('Count: ${count()}, Doubled: ${doubled()}');
+    print('Count: ${count()}, Doubled: ${doubled.value}');
   });
 
   // Update the signal
-  count(1); // Prints: Count: 1, Doubled: 2
+  count.value++; // Prints: Count: 1, Doubled: 2
 }
 ```
 

--- a/bench.dart
+++ b/bench.dart
@@ -9,7 +9,8 @@ class Bench extends ReactiveFramework {
 
   @override
   Computed<T> computed<T>(T Function() fn) {
-    return createComputed(alien_signals.computed<T>((_) => fn()));
+    final c = alien_signals.computed<T>((_) => fn());
+    return createComputed(() => c.value);
   }
 
   @override
@@ -20,7 +21,7 @@ class Bench extends ReactiveFramework {
   @override
   Signal<T> signal<T>(T value) {
     final signal = alien_signals.signal(value);
-    return createSignal(signal, signal);
+    return createSignal(() => signal.value, (value) => signal.value = value);
   }
 
   @override

--- a/example/main.dart
+++ b/example/main.dart
@@ -4,17 +4,17 @@ void basis() {
   print("\n=========== Basic Usage ===========");
 
   final count = signal(1);
-  final doubleCount = computed((_) => count() * 2);
+  final doubleCount = computed((_) => count.value * 2);
 
   effect(() {
-    print("Count is: ${count()}");
+    print("Count is: ${count.value}");
   }); // Count is: 1
 
-  print(doubleCount()); // 2
+  print(doubleCount.value); // 2
 
-  count(2); // Count is: 2
+  count.value = 2; // Count is: 2
 
-  print(doubleCount()); // 4
+  print(doubleCount.value); // 4
 }
 
 void scope() {
@@ -23,13 +23,13 @@ void scope() {
   final count = signal(1);
   final stop = effectScope(() {
     effect(() {
-      print("Count is: ${count()}");
+      print("Count is: ${count.value}");
     }); // Count is: 1
   });
 
-  count(2); // Count is: 2
+  count.value = 2; // Count is: 2
   stop();
-  count(3); // Not printed
+  count.value = 3; // Not printed
 }
 
 void main() {

--- a/example/main.dart
+++ b/example/main.dart
@@ -21,14 +21,14 @@ void scope() {
   print("\n=========== Effect Scope ===========");
 
   final count = signal(1);
-  final stop = effectScope(() {
+  final scope = effectScope(() {
     effect(() {
       print("Count is: ${count.value}");
     }); // Count is: 1
   });
 
   count.value = 2; // Count is: 2
-  stop();
+  scope.dispose();
   count.value = 3; // Not printed
 }
 

--- a/flags.md
+++ b/flags.md
@@ -1,10 +1,10 @@
-| Bit Shift | Flag Name                   | Value | Description   |
-| --------- | --------------------------- | ----- | ------------- |
-| 0         | ReactiveFlags.Node          | 0     | None          |
-| 1 << 0    | ReactiveFlags.Mutable       | 1     | Mutable       |
-| 1 << 1    | ReactiveFlags.Watching      | 2     | Watching      |
-| 1 << 2    | ReactiveFlags.RecursedCheck | 4     | RecursedCheck |
-| 1 << 3    | ReactiveFlags.Recursed      | 8     | Recursed      |
-| 1 << 4    | ReactiveFlags.Dirty         | 16    | Dirty         |
-| 1 << 5    | ReactiveFlags.Pending       | 32    | Pending       |
-| 1 << 6    | ReactiveFlags.Queued        | 64    | Queued        |
+| Bit Shift | Value | Description   |
+| --------- | ----- | ------------- |
+| 0         | 0     | None          |
+| 1 << 0    | 1     | Mutable       |
+| 1 << 1    | 2     | Watching      |
+| 1 << 2    | 4     | RecursedCheck |
+| 1 << 3    | 8     | Recursed      |
+| 1 << 4    | 16    | Dirty         |
+| 1 << 5    | 32    | Pending       |
+| 1 << 6    | 64    | Queued        |

--- a/lib/alien_signals.dart
+++ b/lib/alien_signals.dart
@@ -1,6 +1,3 @@
-@Deprecated('Use `package:alien_signals/system.dart` instead.')
-export 'system.dart';
-
 export "src/preset.dart"
     show
         EffectScope,

--- a/lib/alien_signals.dart
+++ b/lib/alien_signals.dart
@@ -1,5 +1,9 @@
 export "src/preset.dart"
     show
+        Signal,
+        WritableSignal,
+        Computed,
+        Effect,
         EffectScope,
         getBatchDepth,
         getActiveSub,

--- a/lib/alien_signals.dart
+++ b/lib/alien_signals.dart
@@ -1,11 +1,10 @@
-import "src/preset.dart" as preset show batchDepth;
-
 @Deprecated('Use `package:alien_signals/system.dart` instead.')
 export 'system.dart';
 
 export "src/preset.dart"
     show
         EffectScope,
+        getBatchDepth,
         getCurrentSub,
         setCurrentSub,
         startBatch,
@@ -14,9 +13,3 @@ export "src/preset.dart"
         computed,
         effect,
         effectScope;
-
-/// Returns the current batch depth.
-///
-/// The batch depth represents how many nested batches are currently active.
-/// A value of 0 means no batching is currently active.
-int get batchDepth => preset.batchDepth;

--- a/lib/alien_signals.dart
+++ b/lib/alien_signals.dart
@@ -2,8 +2,8 @@ export "src/preset.dart"
     show
         EffectScope,
         getBatchDepth,
-        getCurrentSub,
-        setCurrentSub,
+        getActiveSub,
+        setActiveSub,
         startBatch,
         endBatch,
         signal,

--- a/lib/alien_signals.dart
+++ b/lib/alien_signals.dart
@@ -1,3 +1,6 @@
+/// Alien signals preset library.
+library;
+
 export "src/preset.dart"
     show
         Signal,

--- a/lib/alien_signals.dart
+++ b/lib/alien_signals.dart
@@ -8,8 +8,6 @@ export "src/preset.dart"
         EffectScope,
         getCurrentSub,
         setCurrentSub,
-        getCurrentScope,
-        setCurrentScope,
         startBatch,
         endBatch,
         signal,

--- a/lib/preset_developer.dart
+++ b/lib/preset_developer.dart
@@ -1,0 +1,12 @@
+/// Alien Signal preset for developers.
+///
+/// You can use the presets to further customize.
+library;
+
+export 'src/preset.dart'
+    show
+        PresetComputed,
+        PresetEffect,
+        PresetEffectScope,
+        PresetWritableSignal,
+        system;

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -1,6 +1,6 @@
 import 'system.dart';
 
-final system = PresetReactiveSystem();
+const system = PresetReactiveSystem();
 final link = system.link,
     unlink = system.unlink,
     propagate = system.propagate,
@@ -139,7 +139,7 @@ class PresetComputed<T> extends ReactiveNode implements Updatable, Computed<T> {
 }
 
 class PresetReactiveSystem extends ReactiveSystem {
-  PresetReactiveSystem();
+  const PresetReactiveSystem();
 
   @override
   void notify(ReactiveNode sub) => notifyEffect(sub);

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -300,7 +300,7 @@ Effect effect(void Function() callback) {
       sub = activeSub;
 
   if (sub != null) {
-    link(effect, sub, cycle);
+    link(effect, sub, 0);
   }
 
   final prevSub = setCurrentSub(effect);
@@ -326,7 +326,7 @@ Effect effect(void Function() callback) {
 EffectScope effectScope(void Function() callback) {
   final scope = PresetEffectScope(flags: 0 /* None */), sub = activeSub;
   if (sub != null) {
-    link(scope, sub, cycle);
+    link(scope, sub, 0);
   }
 
   final prevSub = setCurrentSub(scope);

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -444,8 +444,7 @@ void flush() {
 }
 
 void effectOper(ReactiveNode e) {
-  assert(e is Effect || e is EffectScope);
-  var dep = e.deps;
+  Link? dep = e.deps;
   while (dep != null) {
     dep = unlink(dep, e);
   }

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -183,13 +183,13 @@ abstract interface class Computed<T> implements Signal<T> {}
 /// A reactive effect.
 abstract interface class Effect {
   /// Calls the effect on dispose.
-  void call();
+  void dispose();
 }
 
 /// A reactive effect scope.
 abstract interface class EffectScope {
   /// Calls the scope on dispose, notifying all effects.
-  void call();
+  void dispose();
 }
 
 /*--------------------- Preset Impls ---------------------*/
@@ -268,7 +268,7 @@ class PresetEffect extends ReactiveNode implements LinkedEffect, Effect {
   LinkedEffect? nextEffect;
 
   @override
-  void call() => effectOper(this);
+  void dispose() => effectOper(this);
 }
 
 class PresetEffectScope extends ReactiveNode
@@ -279,7 +279,7 @@ class PresetEffectScope extends ReactiveNode
   LinkedEffect? nextEffect;
 
   @override
-  void call() => effectOper(this);
+  void dispose() => effectOper(this);
 }
 
 /*--------------------- Internal Impls ---------------------*/

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -297,13 +297,11 @@ Computed<T> computed<T>(T Function(T? previousValue) getter) {
 /// ```
 Effect effect(void Function() callback) {
   final effect = PresetEffect(callback: callback, flags: 2 /* Watching */),
-      sub = activeSub;
-
-  if (sub != null) {
-    link(effect, sub, 0);
+      prevSub = setActiveSub(effect);
+  if (prevSub != null) {
+    link(effect, prevSub, 0);
   }
 
-  final prevSub = setActiveSub(effect);
   try {
     callback();
     return effect;
@@ -324,12 +322,12 @@ Effect effect(void Function() callback) {
 /// Returns a cleanup function that can be called to dispose of the scope and all
 /// effects created within it.
 EffectScope effectScope(void Function() callback) {
-  final scope = PresetEffectScope(flags: 0 /* None */), sub = activeSub;
-  if (sub != null) {
-    link(scope, sub, 0);
+  final scope = PresetEffectScope(flags: 0 /* None */),
+      prevSub = setActiveSub(scope);
+  if (prevSub != null) {
+    link(scope, prevSub, 0);
   }
 
-  final prevSub = setActiveSub(scope);
   try {
     callback();
     return scope;

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -1,4 +1,4 @@
-import 'system.dart';
+import 'package:alien_signals/system.dart';
 
 /*------------------ Internal variables -------------------*/
 

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -135,6 +135,15 @@ ReactiveNode? activeSub;
 LinkedEffect? queuedEffects;
 LinkedEffect? queuedEffectsTail;
 
+/// Gets the current batch depth.
+///
+/// This returns the current batch depth, which is incremented when a batch
+/// operation is started and decremented when it is completed.
+@pragma('vm:prefer-inline')
+@pragma('wasm:prefer-inline')
+@pragma('dart2js:prefer-inline')
+int getBatchDepth() => batchDepth;
+
 /// Gets the currently active reactive subscription.
 ///
 /// This returns the [ReactiveNode] that is currently being tracked as the active

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -126,7 +126,7 @@ class PresetComputed<T> extends ReactiveNode implements Updatable, Computed<T> {
     depsTail = null;
     flags = 5 /* Mutable | RecursedCheck */;
 
-    final prevSub = setCurrentSub(this);
+    final prevSub = setActiveSub(this);
     try {
       final oldValue = cachedValue;
       return oldValue != (cachedValue = getter(oldValue));
@@ -186,7 +186,7 @@ int getBatchDepth() => batchDepth;
 @pragma('vm:prefer-inline')
 @pragma('wasm:prefer-inline')
 @pragma('dart2js:prefer-inline')
-ReactiveNode? getCurrentSub() => activeSub;
+ReactiveNode? getActiveSub() => activeSub;
 
 /// Sets the currently active reactive subscription and returns the previous one.
 ///
@@ -196,7 +196,7 @@ ReactiveNode? getCurrentSub() => activeSub;
 @pragma('vm:prefer-inline')
 @pragma('wasm:prefer-inline')
 @pragma('dart2js:prefer-inline')
-ReactiveNode? setCurrentSub(ReactiveNode? sub) {
+ReactiveNode? setActiveSub(ReactiveNode? sub) {
   final prevSub = activeSub;
   activeSub = sub;
   return prevSub;
@@ -303,7 +303,7 @@ Effect effect(void Function() callback) {
     link(effect, sub, 0);
   }
 
-  final prevSub = setCurrentSub(effect);
+  final prevSub = setActiveSub(effect);
   try {
     callback();
     return effect;
@@ -329,12 +329,12 @@ EffectScope effectScope(void Function() callback) {
     link(scope, sub, 0);
   }
 
-  final prevSub = setCurrentSub(scope);
+  final prevSub = setActiveSub(scope);
   try {
     callback();
     return scope;
   } finally {
-    setCurrentSub(prevSub);
+    activeSub = prevSub;
   }
 }
 
@@ -370,7 +370,7 @@ void run(ReactiveNode e, int flags) {
     e.depsTail = null;
     e.flags = 6 /* Watching | RecursedCheck */;
 
-    final prevSub = setCurrentSub(e);
+    final prevSub = setActiveSub(e);
     try {
       (e as PresetEffect).callback();
     } finally {
@@ -420,7 +420,7 @@ T computedOper<T>(PresetComputed<T> computed) {
     }
   } else if (flags == 0) {
     computed.flags = 1 /* Mutable */;
-    final prevSub = setCurrentSub(computed);
+    final prevSub = setActiveSub(computed);
     try {
       computed.cachedValue = computed.getter(null);
     } finally {

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -1,8 +1,11 @@
 import 'package:alien_signals/system.dart';
 
+/*------------------- Public variables --------------------*/
+/// Alien signals preset system
+const ReactiveSystem system = PresetReactiveSystem();
+
 /*------------------ Internal variables -------------------*/
 
-const system = PresetReactiveSystem();
 final link = system.link,
     unlink = system.unlink,
     propagate = system.propagate,
@@ -194,10 +197,11 @@ abstract interface class EffectScope {
 
 /*--------------------- Preset Impls ---------------------*/
 
+/// Preset writable signal implementation.
 class PresetWritableSignal<T> extends ReactiveNode
     implements WritableSignal<T> {
   PresetWritableSignal({
-    required super.flags,
+    super.flags = 1 /* Mutable */,
     required T initialValue,
   })  : previousValue = initialValue,
         latestValue = initialValue;
@@ -249,8 +253,9 @@ class PresetWritableSignal<T> extends ReactiveNode
   }
 }
 
+/// Preset computed signal implementation.
 class PresetComputed<T> extends ReactiveNode implements Computed<T> {
-  PresetComputed({required super.flags, required this.getter});
+  PresetComputed({super.flags = 0 /* None */, required this.getter});
 
   T? cachedValue;
   final T Function(T? previousValue) getter;
@@ -309,8 +314,9 @@ abstract interface class LinkedEffect implements ReactiveNode {
   LinkedEffect? nextEffect;
 }
 
+/// Preset effect implementation.
 class PresetEffect extends ReactiveNode implements LinkedEffect, Effect {
-  PresetEffect({required super.flags, required this.callback});
+  PresetEffect({super.flags = 2 /* Watching */, required this.callback});
 
   final void Function() callback;
 
@@ -324,9 +330,10 @@ class PresetEffect extends ReactiveNode implements LinkedEffect, Effect {
   void dispose() => effectOper(this);
 }
 
+/// Preset effect scope implementation.
 class PresetEffectScope extends ReactiveNode
     implements LinkedEffect, EffectScope {
-  PresetEffectScope({required super.flags});
+  PresetEffectScope({super.flags = 0 /* None */});
 
   @override
   LinkedEffect? nextEffect;

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -271,7 +271,7 @@ WritableSignal<T> signal<T>(T initialValue) {
 @pragma('dart2js:prefer-inline')
 Computed<T> computed<T>(T Function(T? previousValue) getter) {
   return PresetComputed(
-    flags: 17 /* Mutable | Dirty */,
+    flags: 0 /* None */,
     getter: getter,
   );
 }
@@ -417,6 +417,14 @@ T computedOper<T>(PresetComputed<T> computed) {
       if (subs != null) {
         shallowPropagate(subs);
       }
+    }
+  } else if (flags == 0) {
+    computed.flags = 1 /* Mutable */;
+    final prevSub = setCurrentSub(computed);
+    try {
+      computed.cachedValue = computed.getter(null);
+    } finally {
+      activeSub = prevSub;
     }
   }
 

--- a/lib/src/system.dart
+++ b/lib/src/system.dart
@@ -103,6 +103,7 @@ final class Stack<T> {
 
 /// A reactive system base class.
 abstract class ReactiveSystem {
+  /// Creates a new reactive system.
   const ReactiveSystem();
 
   /// Updates the node's value if it's dirty and returns whether it was updated.

--- a/lib/system.dart
+++ b/lib/system.dart
@@ -1,1 +1,4 @@
+/// Alien reactive system library.
+library;
+
 export 'src/system.dart' hide Stack;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alien_signals
 description: The lightest signal library - Dart implementation of alien-signals.
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 repository: https://github.com/medz/alien-signals-dart
 
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alien_signals
 description: The lightest signal library - Dart implementation of alien-signals.
-version: 1.0.0
+version: 1.0.0-bate.1
 repository: https://github.com/medz/alien-signals-dart
 
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alien_signals
 description: The lightest signal library - Dart implementation of alien-signals.
-version: 1.0.0-beta.3
+version: 1.0.0-beta.4
 repository: https://github.com/medz/alien-signals-dart
 
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alien_signals
 description: The lightest signal library - Dart implementation of alien-signals.
-version: 1.0.0-bate.1
+version: 1.0.0-beta.1
 repository: https://github.com/medz/alien-signals-dart
 
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alien_signals
 description: The lightest signal library - Dart implementation of alien-signals.
-version: 0.5.4
+version: 1.0.0
 repository: https://github.com/medz/alien-signals-dart
 
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alien_signals
 description: The lightest signal library - Dart implementation of alien-signals.
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 repository: https://github.com/medz/alien-signals-dart
 
 topics:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alien_signals
 description: The lightest signal library - Dart implementation of alien-signals.
-version: 1.0.0-beta.4
+version: 1.0.0
 repository: https://github.com/medz/alien-signals-dart
 
 topics:

--- a/test/computed_test.dart
+++ b/test/computed_test.dart
@@ -4,46 +4,46 @@ import 'package:test/test.dart';
 void main() {
   test("should correctly propagate changes through computed signals", () {
     final s = signal(0);
-    final c1 = computed((_) => s() % 2);
-    final c2 = computed((_) => c1());
-    final c3 = computed((_) => c2());
+    final c1 = computed((_) => s.value % 2);
+    final c2 = computed((_) => c1.value);
+    final c3 = computed((_) => c2.value);
 
-    c3();
-    s(1);
-    c2();
-    s(3);
+    c3.value;
+    s.value = 1;
+    c2.value;
+    s.value = 3;
 
-    expect(c3(), 1);
+    expect(c3.value, 1);
   });
 
   test("should propagate updated source value through chained computations",
       () {
     final s = signal(0);
-    final a = computed((_) => s());
-    final b = computed((_) => a() % 2);
-    final c = computed((_) => s());
-    final d = computed((_) => b() + c());
+    final a = computed((_) => s.value);
+    final b = computed((_) => a.value % 2);
+    final c = computed((_) => s.value);
+    final d = computed((_) => b.value + c.value);
 
-    expect(d(), 0);
-    s(2);
-    expect(d(), 2);
+    expect(d.value, 0);
+    s.value = 2;
+    expect(d.value, 2);
   });
 
   test("should handle flags are indirectly updated during checkDirty", () {
     final a = signal(false);
-    final b = computed((_) => a());
+    final b = computed((_) => a.value);
     final c = computed((_) {
-      b();
+      b.value;
       return 0;
     });
     final d = computed((_) {
-      c();
-      return b();
+      c.value;
+      return b.value;
     });
 
-    expect(d(), false);
-    a(true);
-    expect(d(), true);
+    expect(d.value, false);
+    a.value = true;
+    expect(d.value, true);
   });
 
   test("should not update if the signal value is reverted", () {
@@ -51,14 +51,14 @@ void main() {
     final s = signal(0);
     final c = computed((_) {
       times++;
-      return s();
+      return s.value;
     });
 
-    c();
+    c.value;
     expect(times, 1);
-    s(1);
-    s(0);
-    c();
+    s.value = 1;
+    s.value = 0;
+    c.value;
     expect(times, 1);
   });
 }

--- a/test/effect_scope_test.dart
+++ b/test/effect_scope_test.dart
@@ -5,7 +5,7 @@ void main() {
   test("should not trigger after stop", () {
     int triggers = 0;
     final count = signal(0);
-    final stop = effectScope(() {
+    final EffectScope(:dispose) = effectScope(() {
       effect(() {
         triggers++;
         count.value;
@@ -18,7 +18,7 @@ void main() {
 
     count.value = 3;
     expect(triggers, 3);
-    stop();
+    dispose();
     count.value = 4;
     expect(triggers, 3);
   });
@@ -28,7 +28,7 @@ void main() {
     int triggers = 0;
 
     effect(() {
-      final stop = effectScope(() {
+      final EffectScope(:dispose) = effectScope(() {
         effect(() {
           s.value;
           triggers++;
@@ -39,7 +39,7 @@ void main() {
       s.value = 2;
       expect(triggers, 2);
 
-      stop();
+      dispose();
       s.value = 3;
       expect(triggers, 2);
     });

--- a/test/effect_scope_test.dart
+++ b/test/effect_scope_test.dart
@@ -8,18 +8,18 @@ void main() {
     final stop = effectScope(() {
       effect(() {
         triggers++;
-        count();
+        count.value;
       });
 
       expect(triggers, 1);
-      count(2);
+      count.value = 2;
       expect(triggers, 2);
     });
 
-    count(3);
+    count.value = 3;
     expect(triggers, 3);
     stop();
-    count(4);
+    count.value = 4;
     expect(triggers, 3);
   });
 
@@ -28,19 +28,19 @@ void main() {
     int triggers = 0;
 
     effect(() {
-      final dispose = effectScope(() {
+      final stop = effectScope(() {
         effect(() {
-          s();
+          s.value;
           triggers++;
         });
       });
       expect(triggers, 1);
 
-      s(2);
+      s.value = 2;
       expect(triggers, 2);
 
-      dispose();
-      s(3);
+      stop();
+      s.value = 3;
       expect(triggers, 2);
     });
   });
@@ -52,13 +52,13 @@ void main() {
     int triggers = 0;
     effect(() {
       effectScope(() {
-        source();
+        source.value;
       });
       triggers++;
     });
 
     expect(triggers, equals(1));
-    source(2);
+    source.value = 2;
     expect(triggers, equals(2));
   });
 }

--- a/test/effect_scope_test.dart
+++ b/test/effect_scope_test.dart
@@ -44,4 +44,21 @@ void main() {
       expect(triggers, 2);
     });
   });
+
+  test(
+      'should track signal updates in an inner scope when accessed by an outer effect',
+      () {
+    final source = signal(0);
+    int triggers = 0;
+    effect(() {
+      effectScope(() {
+        source();
+      });
+      triggers++;
+    });
+
+    expect(triggers, equals(1));
+    source(2);
+    expect(triggers, equals(2));
+  });
 }

--- a/test/effect_test.dart
+++ b/test/effect_test.dart
@@ -167,9 +167,9 @@ void main() {
 
     effect(() {
       order.add("a");
-      final currentSub = setCurrentSub(null);
+      final currentSub = setActiveSub(null);
       final isOne = s2.value == 1;
-      setCurrentSub(currentSub);
+      setActiveSub(currentSub);
       if (isOne) s1.value;
       s2.value;
       s1.value;

--- a/test/effect_test.dart
+++ b/test/effect_test.dart
@@ -9,12 +9,14 @@ void main() {
       bRunTimes++;
       return a.value * 2;
     });
-    final stop = effect(() => b.value);
+    final Effect(:dispose) = effect(() => b.value);
 
     expect(bRunTimes, 1);
+
     a.value = 2;
     expect(bRunTimes, 2);
-    stop();
+
+    dispose();
     a.value = 3;
     expect(bRunTimes, 2);
   });
@@ -128,15 +130,15 @@ void main() {
   });
 
   test("should custom effect support batch", () {
-    void Function() batchEffect(void Function() fn) {
-      return effect(() {
+    void batchEffect(void Function() fn) {
+      effect(() {
         startBatch();
         try {
           fn();
         } finally {
           endBatch();
         }
-      }).call;
+      });
     }
 
     final logs = <String>[];

--- a/test/untrack_test.dart
+++ b/test/untrack_test.dart
@@ -10,19 +10,19 @@ void main() {
       computedTriggerTimes++;
       final currentSub = setCurrentSub(null);
       try {
-        return s();
+        return s.value;
       } finally {
         setCurrentSub(currentSub);
       }
     });
 
-    expect(c(), 0);
+    expect(c.value, 0);
     expect(computedTriggerTimes, 1);
 
-    s(1);
-    s(2);
-    s(3);
-    expect(c(), 0);
+    s.value = 1;
+    s.value = 2;
+    s.value = 3;
+    expect(c.value, 0);
     expect(computedTriggerTimes, 1);
   });
 
@@ -33,37 +33,37 @@ void main() {
     int effectTriggerTimes = 0;
     effect(() {
       effectTriggerTimes++;
-      if (b() > 0) {
+      if (b.value > 0) {
         final currentSub = setCurrentSub(null);
-        a();
+        a.value;
         setCurrentSub(currentSub);
       }
     });
 
     expect(effectTriggerTimes, 1);
 
-    b(1);
+    b.value = 1;
     expect(effectTriggerTimes, 2);
 
-    a(1);
-    a(2);
-    a(3);
+    a.value = 1;
+    a.value = 2;
+    a.value = 3;
     expect(effectTriggerTimes, 2);
 
-    b(2);
+    b.value = 2;
     expect(effectTriggerTimes, 3);
 
-    a(4);
-    a(5);
-    a(6);
+    a.value = 4;
+    a.value = 5;
+    a.value = 6;
     expect(effectTriggerTimes, 3);
 
-    b(0);
+    b.value = 0;
     expect(effectTriggerTimes, 4);
 
-    a(7);
-    a(8);
-    a(9);
+    a.value = 7;
+    a.value = 8;
+    a.value = 9;
     expect(effectTriggerTimes, 4);
   });
 
@@ -74,16 +74,16 @@ void main() {
       effect(() {
         effectTriggerTimes++;
         final currentSub = setCurrentSub(null);
-        s();
+        s.value;
         setCurrentSub(currentSub);
       });
     });
 
     expect(effectTriggerTimes, 1);
 
-    s(1);
-    s(2);
-    s(3);
+    s.value = 1;
+    s.value = 2;
+    s.value = 3;
     expect(effectTriggerTimes, 1);
   });
 }

--- a/test/untrack_test.dart
+++ b/test/untrack_test.dart
@@ -8,11 +8,11 @@ void main() {
 
     final c = computed((_) {
       computedTriggerTimes++;
-      final currentSub = setCurrentSub(null);
+      final currentSub = setActiveSub(null);
       try {
         return s.value;
       } finally {
-        setCurrentSub(currentSub);
+        setActiveSub(currentSub);
       }
     });
 
@@ -34,9 +34,9 @@ void main() {
     effect(() {
       effectTriggerTimes++;
       if (b.value > 0) {
-        final currentSub = setCurrentSub(null);
+        final currentSub = setActiveSub(null);
         a.value;
-        setCurrentSub(currentSub);
+        setActiveSub(currentSub);
       }
     });
 
@@ -73,9 +73,9 @@ void main() {
     effectScope(() {
       effect(() {
         effectTriggerTimes++;
-        final currentSub = setCurrentSub(null);
+        final currentSub = setActiveSub(null);
         s.value;
-        setCurrentSub(currentSub);
+        setActiveSub(currentSub);
       });
     });
 


### PR DESCRIPTION
alien_signals has been relatively stable for a long time. With the upstream release of [alient-signals](https://github.com/stackblitz/alien-signals) 3.0.0, we are releasing our first stable version.

### Long-standing issues in 0.x versions:

- The `call()` API is not compatible with Dart. If the signal's `T` is nullable, a second argument must be passed to update it to a `null` value.
- The `call()` API has many inconveniences when updating itself, for example, `s(s() + 1)` vs. `s.value++`
- Because all previous APIs returned closure functions, it was difficult to detect the signal type externally.

### 1.0 Plans

1. Only the Reactive system will be synchronized with the upstream.
2. Implement a preset API suitable for Dart.
3. Release the official version (1.0). Presets remain stable.