### PR TITLE
feat: sync upstream v3.2.1 reactivity updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.0
 
+- fix: keep computed-chain propagation active after inner writes
 - fix: make `effectScope()` participate in dependency propagation
 - fix: make `checkDirty()` resilient to graph mutations during updates
 - refactor: tighten `checkDirty()` subscriber snapshot handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fix: keep computed-chain propagation active after inner writes
 - fix: make `effectScope()` participate in dependency propagation
 - fix: make `checkDirty()` resilient to graph mutations during updates
+- refactor: remove redundant run-depth tracking from computed evaluation
 - refactor: tighten `checkDirty()` subscriber snapshot handling
 - refactor: hoist `trigger()` flag reset before dependency propagation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+- refactor: hoist `trigger()` flag reset before dependency propagation
+
 ## 2.2.0
 
 - build: bump minimum Dart SDK to `^3.8.0` and refresh dev dependency constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,30 @@
 ## 2.3.0
 
-- feat: support cleanup callbacks returned from `effect()`
-- fix: dispose nested effects before parent cleanup in reverse order
-- fix: preserve outer effect subscriptions after inner effect re-runs
-- fix: run effect cleanup outside dependency tracking on dispose
-- fix: keep computed-chain propagation active after inner writes
-- fix: make `effectScope()` participate in dependency propagation
-- fix: make `checkDirty()` resilient to graph mutations during updates
-- refactor: remove redundant run-depth tracking from computed evaluation
-- refactor: tighten `checkDirty()` subscriber snapshot handling
-- refactor: hoist `trigger()` flag reset before dependency propagation
+> Sync upstream [alien-signals](https://github.com/stackblitz/alien-signals/commit/8734d386d925025d0e99419bd9161c17b112c5ee)<sup>v3.2.1</sup>
+
+### Added
+
+- Add cleanup callback support for `effect()`; callbacks may return a function
+  that runs before the next effect execution and when the effect is stopped.
+
+### Fixed
+
+- Dispose nested effects and scopes before parent cleanup, using reverse
+  creation order for siblings and depth-first cleanup for nested children.
+- Preserve outer effect subscriptions after inner effects re-run.
+- Keep computed-chain propagation active when a signal is written from inside an
+  effect.
+- Make `effectScope()` participate in dependency propagation so nested scopes
+  can invalidate their parent effect correctly.
+- Make `checkDirty()` resilient to graph mutations while dependencies are being
+  updated.
+- Run effect cleanup callbacks outside dependency tracking.
+
+### Changed
+
+- Hoist `trigger()` flag reset before dependency propagation.
+- Tighten `checkDirty()` subscriber snapshot handling.
+- Remove redundant run-depth tracking from computed evaluation.
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.0
 
 - feat: support cleanup callbacks returned from `effect()`
+- fix: run effect cleanup outside dependency tracking on dispose
 - fix: keep computed-chain propagation active after inner writes
 - fix: make `effectScope()` participate in dependency propagation
 - fix: make `checkDirty()` resilient to graph mutations during updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.0
 
 - feat: support cleanup callbacks returned from `effect()`
+- fix: preserve outer effect subscriptions after inner effect re-runs
 - fix: run effect cleanup outside dependency tracking on dispose
 - fix: keep computed-chain propagation active after inner writes
 - fix: make `effectScope()` participate in dependency propagation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.0
 
 - feat: support cleanup callbacks returned from `effect()`
+- fix: dispose nested effects before parent cleanup in reverse order
 - fix: preserve outer effect subscriptions after inner effect re-runs
 - fix: run effect cleanup outside dependency tracking on dispose
 - fix: keep computed-chain propagation active after inner writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.0
 
+- feat: support cleanup callbacks returned from `effect()`
 - fix: keep computed-chain propagation active after inner writes
 - fix: make `effectScope()` participate in dependency propagation
 - fix: make `checkDirty()` resilient to graph mutations during updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.0
 
+- fix: make `effectScope()` participate in dependency propagation
 - fix: make `checkDirty()` resilient to graph mutations during updates
 - refactor: tighten `checkDirty()` subscriber snapshot handling
 - refactor: hoist `trigger()` flag reset before dependency propagation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.0
 
 - fix: make `checkDirty()` resilient to graph mutations during updates
+- refactor: tighten `checkDirty()` subscriber snapshot handling
 - refactor: hoist `trigger()` flag reset before dependency propagation
 
 ## 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.0
 
+- fix: make `checkDirty()` resilient to graph mutations during updates
 - refactor: hoist `trigger()` flag reset before dependency propagation
 
 ## 2.2.0

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,7 @@ projects extend to build their own surface APIs.
 ### Node types
 - `SignalNode<T>`: `get()`, `set()`, `didUpdate()`.
 - `ComputedNode<T>`: `get()`, `didUpdate()`.
-- `EffectNode` / `LinkedEffect`: effect execution + queue linkage.
+- `EffectNode<T>` / `LinkedEffect`: effect execution + queue linkage.
 - `PresetReactiveSystem`: concrete `ReactiveSystem` implementation.
 
 ### Runtime helpers
@@ -60,9 +60,14 @@ Thin wrapper on the preset for out-of-the-box signals.
 ```dart
 WritableSignal<T> signal<T>(T initialValue)
 Computed<T> computed<T>(T Function(T?) getter)
-Effect effect(void Function() fn)
+typedef EffectCleanup = void Function()
+typedef EffectCallback<T> = T Function()
+Effect effect<T>(EffectCallback<T> fn)
 EffectScope effectScope(void Function() fn)
 void startBatch()
 void endBatch()
 void trigger(void Function() fn)
 ```
+
+`effect()` callbacks may return a `void Function()` cleanup. The cleanup runs
+before the effect re-runs and when the effect is stopped.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -79,7 +79,7 @@ MyComputed<T> myComputed<T>(T Function(T?) getter) => MyComputed(getter);
 `EffectNode` handles scheduling; you still need to wire dependency tracking and
 provide a disposable handle.
 ```dart
-class MyEffect extends EffectNode {
+class MyEffect extends EffectNode<void> {
   MyEffect(void Function() fn)
       : super(flags: ReactiveFlags.watching | ReactiveFlags.recursedCheck,
               fn: fn);

--- a/example/preset_playground.dart
+++ b/example/preset_playground.dart
@@ -30,9 +30,9 @@ extension type computed<T>._(ComputedNode<T> _) {
   T get value => _.get();
 }
 
-extension type effect._(EffectNode _) {
+extension type effect._(EffectNode<void> _) {
   factory effect(void Function() run) {
-    final node = EffectNode(
+    final node = EffectNode<void>(
       fn: run,
       flags: ReactiveFlags.watching | ReactiveFlags.recursedCheck,
     );

--- a/lib/alien_signals.dart
+++ b/lib/alien_signals.dart
@@ -1,2 +1,3 @@
-export 'src/preset.dart' show startBatch, endBatch, trigger;
+export 'src/preset.dart'
+    show EffectCallback, EffectCleanup, startBatch, endBatch, trigger;
 export 'src/surface.dart';

--- a/lib/preset.dart
+++ b/lib/preset.dart
@@ -1,1 +1,1 @@
-export 'src/preset.dart' hide system;
+export 'src/preset.dart' hide system, hasChildEffect;

--- a/lib/preset.dart
+++ b/lib/preset.dart
@@ -1,1 +1,1 @@
-export 'src/preset.dart' hide system, hasChildEffect;
+export 'src/preset.dart' hide system, hasChildEffect, shouldTrack;

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -531,7 +531,7 @@ void run(EffectNode e) {
       e.flags &= -5 /*~ReactiveFlags.recursedCheck*/;
       purgeDeps(e);
     }
-  } else if (e.flags != ReactiveFlags.none) {
+  } else if (e.deps != null) {
     e.flags = ReactiveFlags.watching;
   }
 }

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -51,6 +51,9 @@ typedef EffectCleanup = void Function();
 /// Callback passed to an effect.
 typedef EffectCallback<T> = T Function();
 
+/// Marks a parent effect, scope, or computed whose deps include a child effect.
+const hasChildEffect = 64 as ReactiveFlags;
+
 /// A reactive node that can be linked in a queue of effects.
 ///
 /// Extends [ReactiveNode] to add queueing capabilities, allowing
@@ -226,6 +229,9 @@ class ComputedNode<T> extends ReactiveNode {
   ///
   /// Returns `true` if the computed value changed, `false` otherwise.
   bool didUpdate() {
+    if ((flags & hasChildEffect) != ReactiveFlags.none) {
+      disposeChildDepsInReverse(this);
+    }
     depsTail = null;
     flags = ReactiveFlags.mutable | ReactiveFlags.recursedCheck;
     final prevSub = setActiveSub(this);
@@ -378,18 +384,26 @@ class PresetReactiveSystem extends ReactiveSystem {
 
   /// Called when a node no longer has any subscribers.
   ///
-  /// For non-mutable nodes (like effects), stops them completely.
-  /// For mutable nodes (like signals), marks them as dirty and
-  /// clears their dependencies for lazy re-evaluation.
+  /// Computed nodes become dirty and release their dependencies lazily,
+  /// signals stay alive, and effect-like nodes are stopped immediately.
   @override
   void unwatched(ReactiveNode node) {
-    if ((node.flags & ReactiveFlags.mutable) == ReactiveFlags.none) {
-      stop(node);
-    } else if (node.depsTail != null) {
-      node.depsTail = null;
-      node.flags =
-          17 /*ReactiveFlags.mutable | ReactiveFlags.dirty*/ as ReactiveFlags;
-      purgeDeps(node);
+    switch (node) {
+      case ComputedNode():
+        if (node.depsTail != null) {
+          node.flags =
+              17 /*ReactiveFlags.mutable | ReactiveFlags.dirty*/
+                  as ReactiveFlags;
+          disposeAllDepsInReverse(node);
+        }
+      case SignalNode():
+        break;
+      case EffectNode():
+        stopEffect(node);
+      case EffectScopeNode():
+        stopScope(node);
+      case _:
+        stop(node);
     }
   }
 }
@@ -510,6 +524,9 @@ void run(EffectNode e) {
       && checkDirty(e.deps!, e)
     )
   ) { // dart format on
+    if ((flags & hasChildEffect) != ReactiveFlags.none) {
+      disposeChildDepsInReverse(e);
+    }
     if (e.cleanup != null) {
       runCleanup(e);
       if (e.flags == ReactiveFlags.none) {
@@ -532,7 +549,7 @@ void run(EffectNode e) {
       purgeDeps(e);
     }
   } else if (e.deps != null) {
-    e.flags = ReactiveFlags.watching;
+    e.flags = ReactiveFlags.watching | (flags & hasChildEffect);
   }
 }
 
@@ -582,17 +599,27 @@ void flush() {
 ///
 /// This is essential for cleanup to prevent memory leaks.
 void stop(ReactiveNode node) {
-  if (node is EffectNode) {
-    if (node.cleanup != null) {
-      runCleanup(node);
-    }
+  switch (node) {
+    case EffectNode():
+      stopEffect(node);
+    case EffectScopeNode():
+      stopScope(node);
+    case _:
+      node.depsTail = null;
+      node.flags = ReactiveFlags.none;
+      purgeDeps(node);
+      final subs = node.subs;
+      if (subs != null) {
+        unlink(subs, subs.sub);
+      }
   }
-  node.depsTail = null;
-  node.flags = ReactiveFlags.none;
-  purgeDeps(node);
-  final subs = node.subs;
-  if (subs != null) {
-    unlink(subs, subs.sub);
+}
+
+/// Stops an effect after disposing its nested effects and scopes.
+void stopEffect(EffectNode e) {
+  stopScope(e);
+  if (e.cleanup != null) {
+    runCleanup(e);
   }
 }
 
@@ -606,6 +633,39 @@ void runCleanup(EffectNode e) {
     cleanup();
   } finally {
     activeSub = prevSub;
+  }
+}
+
+/// Stops a scope-like node and disposes all dependencies in reverse order.
+void stopScope(ReactiveNode node) {
+  node.flags = ReactiveFlags.none;
+  disposeAllDepsInReverse(node);
+  final subs = node.subs;
+  if (subs != null) {
+    unlink(subs, subs.sub);
+  }
+}
+
+/// Disposes child effects/scopes while leaving signal/computed deps for purge.
+void disposeChildDepsInReverse(ReactiveNode sub) {
+  Link? link = sub.depsTail;
+  while (link != null) {
+    final prev = link.prevDep;
+    final dep = link.dep;
+    if (dep is! ComputedNode && dep is! SignalNode) {
+      unlink(link, sub);
+    }
+    link = prev;
+  }
+}
+
+/// Removes every dependency from [sub], starting from the newest link.
+void disposeAllDepsInReverse(ReactiveNode sub) {
+  Link? link = sub.depsTail;
+  while (link != null) {
+    final prev = link.prevDep;
+    unlink(link, sub);
+    link = prev;
   }
 }
 

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -497,7 +497,7 @@ void run(EffectNode e) {
       e.flags &= -5 /*~ReactiveFlags.recursedCheck*/;
       purgeDeps(e);
     }
-  } else {
+  } else if (e.flags != ReactiveFlags.none) {
     e.flags = ReactiveFlags.watching;
   }
 }

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -6,6 +6,11 @@ import 'package:alien_signals/system.dart';
 /// dependencies are properly tracked and invalidated.
 int cycle = 0;
 
+/// Current depth of nested reactive computations.
+///
+/// When greater than 0, writes happen from inside an effect or computed getter.
+int runDepth = 0;
+
 /// Current depth of nested batch operations.
 ///
 /// When greater than 0, effect execution is deferred until
@@ -98,7 +103,7 @@ class SignalNode<T> extends ReactiveNode {
       flags =
           17 /*ReactiveFlags.mutable | ReactiveFlags.dirty*/ as ReactiveFlags;
       if (subs case final Link subs) {
-        propagate(subs);
+        propagate(subs, runDepth > 0);
         if (batchDepth == 0) flush();
       }
     }
@@ -195,8 +200,10 @@ class ComputedNode<T> extends ReactiveNode {
               as ReactiveFlags;
       final prevSub = setActiveSub(this);
       try {
+        ++runDepth;
         currentValue = getter(null);
       } finally {
+        --runDepth;
         activeSub = prevSub;
         this.flags &= -5 /*~ReactiveFlags.recursedCheck*/;
       }
@@ -215,13 +222,15 @@ class ComputedNode<T> extends ReactiveNode {
   ///
   /// Returns `true` if the computed value changed, `false` otherwise.
   bool didUpdate() {
-    ++cycle;
     depsTail = null;
     flags = ReactiveFlags.mutable | ReactiveFlags.recursedCheck;
     final prevSub = setActiveSub(this);
     try {
+      ++cycle;
+      ++runDepth;
       return !identical(currentValue, currentValue = getter(currentValue));
     } finally {
+      --runDepth;
       activeSub = prevSub;
       flags &= -5 /*~ReactiveFlags.recursedCheck*/;
       purgeDeps(this);
@@ -466,7 +475,7 @@ void trigger(void Function() fn) {
 
       final subs = dep.subs;
       if (subs != null) {
-        propagate(subs);
+        propagate(subs, runDepth > 0);
         shallowPropagate(subs);
       }
     }
@@ -491,15 +500,17 @@ void run(EffectNode e) {
       && checkDirty(e.deps!, e)
     )
   ) { // dart format on
-    ++cycle;
     e.depsTail = null;
     e.flags =
         6 /*ReactiveFlags.watching | ReactiveFlags.recursedCheck*/
             as ReactiveFlags;
     final prevSub = setActiveSub(e);
     try {
+      ++cycle;
+      ++runDepth;
       e.fn();
     } finally {
+      --runDepth;
       activeSub = prevSub;
       e.flags &= -5 /*~ReactiveFlags.recursedCheck*/;
       purgeDeps(e);

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -514,16 +514,8 @@ void run(EffectNode e) {
       && checkDirty(e.deps!, e)
     )
   ) { // dart format on
-    final cleanup = e.cleanup;
-    if (cleanup != null) {
-      e.cleanup = null;
-      final prevSub = activeSub;
-      activeSub = null;
-      try {
-        cleanup();
-      } finally {
-        activeSub = prevSub;
-      }
+    if (e.cleanup != null) {
+      runCleanup(e);
       if (e.flags == ReactiveFlags.none) {
         return;
       }
@@ -595,10 +587,8 @@ void flush() {
 /// This is essential for cleanup to prevent memory leaks.
 void stop(ReactiveNode node) {
   if (node is EffectNode) {
-    final cleanup = node.cleanup;
-    if (cleanup != null) {
-      node.cleanup = null;
-      cleanup();
+    if (node.cleanup != null) {
+      runCleanup(node);
     }
   }
   node.depsTail = null;
@@ -607,6 +597,19 @@ void stop(ReactiveNode node) {
   final subs = node.subs;
   if (subs != null) {
     unlink(subs, subs.sub);
+  }
+}
+
+/// Runs an effect cleanup outside dependency tracking.
+void runCleanup(EffectNode e) {
+  final cleanup = e.cleanup!;
+  e.cleanup = null;
+  final prevSub = activeSub;
+  activeSub = null;
+  try {
+    cleanup();
+  } finally {
+    activeSub = prevSub;
   }
 }
 

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -6,9 +6,10 @@ import 'package:alien_signals/system.dart';
 /// dependencies are properly tracked and invalidated.
 int cycle = 0;
 
-/// Current depth of nested reactive computations.
+/// Current depth of nested effect callback execution.
 ///
-/// When greater than 0, writes happen from inside an effect or computed getter.
+/// Incremented by effect runs, not by standalone computed evaluation. When
+/// greater than 0, writes should be treated as inner writes during propagation.
 int runDepth = 0;
 
 /// Current depth of nested batch operations.
@@ -53,6 +54,15 @@ typedef EffectCallback<T> = T Function();
 
 /// Marks a parent effect, scope, or computed whose deps include a child effect.
 const hasChildEffect = 64 as ReactiveFlags;
+
+/// Whether a subscriber is still eligible to track dependencies.
+@pragma('vm:prefer-inline')
+@pragma('dart2js:tryInline')
+@pragma('wasm:prefer-inline')
+bool shouldTrack(ReactiveNode sub) {
+  return (sub.flags & 3 /*ReactiveFlags.mutable | ReactiveFlags.watching*/ ) !=
+      ReactiveFlags.none;
+}
 
 /// A reactive node that can be linked in a queue of effects.
 ///
@@ -136,7 +146,7 @@ class SignalNode<T> extends ReactiveNode {
       }
     }
     final sub = activeSub;
-    if (sub != null) {
+    if (sub != null && shouldTrack(sub)) {
       link(this, sub, cycle);
     }
     return currentValue;
@@ -217,7 +227,7 @@ class ComputedNode<T> extends ReactiveNode {
     }
 
     final sub = activeSub;
-    if (sub != null) link(this, sub, cycle);
+    if (sub != null && shouldTrack(sub)) link(this, sub, cycle);
 
     return currentValue as T;
   }

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -206,10 +206,8 @@ class ComputedNode<T> extends ReactiveNode {
               as ReactiveFlags;
       final prevSub = setActiveSub(this);
       try {
-        ++runDepth;
         currentValue = getter(null);
       } finally {
-        --runDepth;
         activeSub = prevSub;
         this.flags &= -5 /*~ReactiveFlags.recursedCheck*/;
       }
@@ -233,10 +231,8 @@ class ComputedNode<T> extends ReactiveNode {
     final prevSub = setActiveSub(this);
     try {
       ++cycle;
-      ++runDepth;
       return !identical(currentValue, currentValue = getter(currentValue));
     } finally {
-      --runDepth;
       activeSub = prevSub;
       flags &= -5 /*~ReactiveFlags.recursedCheck*/;
       purgeDeps(this);

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -451,6 +451,7 @@ void trigger(void Function() fn) {
     fn();
   } finally {
     activeSub = prevSub;
+    sub.flags = ReactiveFlags.none;
     Link? link = sub.deps;
     while (link != null) {
       final dep = link.dep;
@@ -458,7 +459,6 @@ void trigger(void Function() fn) {
 
       final subs = dep.subs;
       if (subs != null) {
-        sub.flags = ReactiveFlags.none;
         propagate(subs);
         shallowPropagate(subs);
       }

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -121,17 +121,9 @@ class SignalNode<T> extends ReactiveNode {
         }
       }
     }
-    ReactiveNode? sub = activeSub;
-    while (sub != null) {
-      // dart format off
-      if (
-        (sub.flags & 3 /*(ReactiveFlags.mutable | ReactiveFlags.watching)*/ ) !=
-        ReactiveFlags.none
-      ) { // dart format on
-        link(this, sub, cycle);
-        break;
-      }
-      sub = sub.subs?.sub;
+    final sub = activeSub;
+    if (sub != null) {
+      link(this, sub, cycle);
     }
     return currentValue;
   }
@@ -237,6 +229,20 @@ class ComputedNode<T> extends ReactiveNode {
   }
 }
 
+/// A reactive effect scope node that can participate in propagation.
+class EffectScopeNode extends ReactiveNode {
+  EffectScopeNode({required super.flags});
+
+  /// Marks the scope as mutable while dirty checking propagates through it.
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:tryInline')
+  @pragma('wasm:prefer-inline')
+  bool didUpdate() {
+    flags = ReactiveFlags.mutable;
+    return true;
+  }
+}
+
 /// A reactive effect node that runs side effects in response to changes.
 ///
 /// EffectNode extends [LinkedEffect] to add the capability to execute
@@ -309,6 +315,7 @@ class PresetReactiveSystem extends ReactiveSystem {
     return switch (node) {
       ComputedNode() => node.didUpdate(),
       SignalNode() => node.didUpdate(),
+      EffectScopeNode() => node.didUpdate(),
       _ => false,
     };
   }

--- a/lib/src/preset.dart
+++ b/lib/src/preset.dart
@@ -45,6 +45,12 @@ final link = system.link,
     checkDirty = system.checkDirty,
     shallowPropagate = system.shallowPropagate;
 
+/// Cleanup function returned by an effect callback.
+typedef EffectCleanup = void Function();
+
+/// Callback passed to an effect.
+typedef EffectCallback<T> = T Function();
+
 /// A reactive node that can be linked in a queue of effects.
 ///
 /// Extends [ReactiveNode] to add queueing capabilities, allowing
@@ -254,18 +260,26 @@ class EffectScopeNode extends ReactiveNode {
 
 /// A reactive effect node that runs side effects in response to changes.
 ///
-/// EffectNode extends [LinkedEffect] to add the capability to execute
-/// a function when its dependencies change. Effects are the bridge
-/// between the reactive system and the outside world, allowing
-/// side effects like DOM updates or logging.
-class EffectNode extends LinkedEffect {
+/// EffectNode extends [LinkedEffect] to add the typed effect callback.
+/// Effects are the bridge between the reactive system and the outside world,
+/// allowing side effects like DOM updates or logging.
+class EffectNode<T> extends LinkedEffect {
   /// The side effect function to execute.
   ///
   /// This function is called whenever any of the effect's
   /// dependencies change.
-  final void Function() fn;
+  final EffectCallback<T> fn;
 
-  EffectNode({required super.flags, required this.fn});
+  /// Cleanup function returned by the latest effect execution.
+  EffectCleanup? cleanup;
+
+  EffectNode({required super.flags, required this.fn, this.cleanup});
+
+  /// Runs the effect callback and returns a cleanup if one was provided.
+  EffectCleanup? runEffect() {
+    final result = fn();
+    return result is EffectCleanup ? result : null;
+  }
 }
 
 /// Default implementation of the reactive system for Alien Signals.
@@ -500,6 +514,20 @@ void run(EffectNode e) {
       && checkDirty(e.deps!, e)
     )
   ) { // dart format on
+    final cleanup = e.cleanup;
+    if (cleanup != null) {
+      e.cleanup = null;
+      final prevSub = activeSub;
+      activeSub = null;
+      try {
+        cleanup();
+      } finally {
+        activeSub = prevSub;
+      }
+      if (e.flags == ReactiveFlags.none) {
+        return;
+      }
+    }
     e.depsTail = null;
     e.flags =
         6 /*ReactiveFlags.watching | ReactiveFlags.recursedCheck*/
@@ -508,7 +536,7 @@ void run(EffectNode e) {
     try {
       ++cycle;
       ++runDepth;
-      e.fn();
+      e.cleanup = e.runEffect();
     } finally {
       --runDepth;
       activeSub = prevSub;
@@ -566,6 +594,13 @@ void flush() {
 ///
 /// This is essential for cleanup to prevent memory leaks.
 void stop(ReactiveNode node) {
+  if (node is EffectNode) {
+    final cleanup = node.cleanup;
+    if (cleanup != null) {
+      node.cleanup = null;
+      cleanup();
+    }
+  }
   node.depsTail = null;
   node.flags = ReactiveFlags.none;
   purgeDeps(node);

--- a/lib/src/surface.dart
+++ b/lib/src/surface.dart
@@ -8,7 +8,8 @@ import 'package:alien_signals/preset.dart'
         SignalNode,
         ComputedNode,
         EffectNode,
-        EffectScopeNode;
+        EffectScopeNode,
+        EffectCallback;
 import 'package:alien_signals/system.dart' show ReactiveFlags;
 
 /// A reactive signal that holds a value of type [T].
@@ -196,7 +197,8 @@ Computed<T> computed<T>(T Function(T?) getter) {
 /// execution and re-run when those signals change.
 ///
 /// The effect runs immediately upon creation and then again whenever
-/// its dependencies change.
+/// its dependencies change. The callback may return a cleanup function that
+/// runs before the next execution and when the effect is stopped.
 ///
 /// The returned [Effect] can be called to stop the effect and clean up
 /// its subscriptions.
@@ -220,14 +222,14 @@ Computed<T> computed<T>(T Function(T?) getter) {
 /// - Parameter [fn]: The function to run as an effect. Will be executed
 ///   immediately and re-executed when dependencies change.
 /// - Returns: An [Effect] that can be called to stop it.
-Effect effect(void Function() fn) {
+Effect effect<T>(EffectCallback<T> fn) {
   // dart format off
   final e = _EffectImpl(fn: fn, flags: 6 /* ReactiveFlags.watching | ReactiveFlags.recursedCheck */ as ReactiveFlags),// dart format on
       prevSub = setActiveSub(e);
   if (prevSub != null) link(e, prevSub, 0);
   try {
     ++runDepth;
-    fn();
+    e.cleanup = e.runEffect();
     return e;
   } finally {
     --runDepth;
@@ -307,7 +309,7 @@ final class _ComputedImpl<T> extends ComputedNode<T> implements Computed<T> {
   T call() => get();
 }
 
-final class _EffectImpl extends EffectNode implements Effect {
+final class _EffectImpl<T> extends EffectNode<T> implements Effect {
   _EffectImpl({required super.flags, required super.fn});
 
   @override

--- a/lib/src/surface.dart
+++ b/lib/src/surface.dart
@@ -6,6 +6,7 @@ import 'preset.dart'
         link,
         stop,
         hasChildEffect,
+        shouldTrack,
         SignalNode,
         ComputedNode,
         EffectNode,
@@ -227,7 +228,7 @@ Effect effect<T>(EffectCallback<T> fn) {
   // dart format off
   final e = _EffectImpl(fn: fn, flags: 6 /* ReactiveFlags.watching | ReactiveFlags.recursedCheck */ as ReactiveFlags),// dart format on
       prevSub = setActiveSub(e);
-  if (prevSub != null) {
+  if (prevSub != null && shouldTrack(prevSub)) {
     link(e, prevSub, 0);
     prevSub.flags |= hasChildEffect;
   }
@@ -235,6 +236,9 @@ Effect effect<T>(EffectCallback<T> fn) {
     ++runDepth;
     e.cleanup = e.runEffect();
     return e;
+  } catch (_) {
+    stop(e);
+    rethrow;
   } finally {
     --runDepth;
     activeSub = prevSub;
@@ -280,13 +284,16 @@ Effect effect<T>(EffectCallback<T> fn) {
 EffectScope effectScope(void Function() fn) {
   final e = _EffectScopeImpl(flags: ReactiveFlags.mutable),
       prevSub = setActiveSub(e);
-  if (prevSub != null) {
+  if (prevSub != null && shouldTrack(prevSub)) {
     link(e, prevSub, 0);
     prevSub.flags |= hasChildEffect;
   }
   try {
     fn();
     return e;
+  } catch (_) {
+    stop(e);
+    rethrow;
   } finally {
     activeSub = prevSub;
   }

--- a/lib/src/surface.dart
+++ b/lib/src/surface.dart
@@ -1,10 +1,11 @@
-import 'package:alien_signals/preset.dart'
+import 'preset.dart'
     show
         setActiveSub,
         activeSub,
         runDepth,
         link,
         stop,
+        hasChildEffect,
         SignalNode,
         ComputedNode,
         EffectNode,
@@ -226,7 +227,10 @@ Effect effect<T>(EffectCallback<T> fn) {
   // dart format off
   final e = _EffectImpl(fn: fn, flags: 6 /* ReactiveFlags.watching | ReactiveFlags.recursedCheck */ as ReactiveFlags),// dart format on
       prevSub = setActiveSub(e);
-  if (prevSub != null) link(e, prevSub, 0);
+  if (prevSub != null) {
+    link(e, prevSub, 0);
+    prevSub.flags |= hasChildEffect;
+  }
   try {
     ++runDepth;
     e.cleanup = e.runEffect();
@@ -276,7 +280,10 @@ Effect effect<T>(EffectCallback<T> fn) {
 EffectScope effectScope(void Function() fn) {
   final e = _EffectScopeImpl(flags: ReactiveFlags.mutable),
       prevSub = setActiveSub(e);
-  if (prevSub != null) link(e, prevSub, 0);
+  if (prevSub != null) {
+    link(e, prevSub, 0);
+    prevSub.flags |= hasChildEffect;
+  }
   try {
     fn();
     return e;

--- a/lib/src/surface.dart
+++ b/lib/src/surface.dart
@@ -2,6 +2,7 @@ import 'package:alien_signals/preset.dart'
     show
         setActiveSub,
         activeSub,
+        runDepth,
         link,
         stop,
         SignalNode,
@@ -225,9 +226,11 @@ Effect effect(void Function() fn) {
       prevSub = setActiveSub(e);
   if (prevSub != null) link(e, prevSub, 0);
   try {
+    ++runDepth;
     fn();
     return e;
   } finally {
+    --runDepth;
     activeSub = prevSub;
     e.flags &= -5 /*~ ReactiveFlags.recursedCheck */;
   }

--- a/lib/src/surface.dart
+++ b/lib/src/surface.dart
@@ -6,8 +6,9 @@ import 'package:alien_signals/preset.dart'
         stop,
         SignalNode,
         ComputedNode,
-        EffectNode;
-import 'package:alien_signals/system.dart' show ReactiveFlags, ReactiveNode;
+        EffectNode,
+        EffectScopeNode;
+import 'package:alien_signals/system.dart' show ReactiveFlags;
 
 /// A reactive signal that holds a value of type [T].
 ///
@@ -268,7 +269,7 @@ Effect effect(void Function() fn) {
 @pragma('dart2js:tryInline')
 @pragma('wasm:prefer-inline')
 EffectScope effectScope(void Function() fn) {
-  final e = _EffectScopeImpl(flags: ReactiveFlags.none),
+  final e = _EffectScopeImpl(flags: ReactiveFlags.mutable),
       prevSub = setActiveSub(e);
   if (prevSub != null) link(e, prevSub, 0);
   try {
@@ -313,7 +314,7 @@ final class _EffectImpl extends EffectNode implements Effect {
   void call() => stop(this);
 }
 
-class _EffectScopeImpl extends ReactiveNode implements EffectScope {
+class _EffectScopeImpl extends EffectScopeNode implements EffectScope {
   _EffectScopeImpl({required super.flags});
 
   @override

--- a/lib/src/system.dart
+++ b/lib/src/system.dart
@@ -346,7 +346,7 @@ abstract class ReactiveSystem {
   /// The propagation stops at non-mutable nodes (like effects) or when
   /// circular dependencies are detected.
   @pragma('vm:align-loops')
-  void propagate(Link link) {
+  void propagate(Link link, [bool innerWrite = false]) {
     Link? next = link.nextSub;
     Stack<Link?>? stack;
 
@@ -360,6 +360,9 @@ abstract class ReactiveSystem {
         (flags & 60 /*ReactiveFlags.recursedCheck | ReactiveFlags.recursed | ReactiveFlags.dirty | ReactiveFlags.pending*/ ) == ReactiveFlags.none
       ) {
         sub.flags = flags | ReactiveFlags.pending;
+        if (innerWrite) {
+          sub.flags |= ReactiveFlags.recursed;
+        }
       } else if (
         (flags & 12 /*ReactiveFlags.recursedCheck | ReactiveFlags.recursed*/ ) == ReactiveFlags.none
       ) {

--- a/lib/src/system.dart
+++ b/lib/src/system.dart
@@ -462,7 +462,7 @@ abstract class ReactiveSystem {
       } else if ((flags & 17 /*(ReactiveFlags.mutable | ReactiveFlags.dirty)*/ ) == 17 /*(ReactiveFlags.mutable | ReactiveFlags.dirty)*/) {
         final subs = dep.subs;
         if (update(dep)) {
-          if (subs != null && subs.nextSub != null) {
+          if (subs!.nextSub != null) {
             shallowPropagate(subs);
           }
           dirty = true;
@@ -489,7 +489,7 @@ abstract class ReactiveSystem {
         if (dirty) {
           final subs = sub.subs;
           if (update(sub)) {
-            if (subs != null && subs.nextSub != null) {
+            if (subs!.nextSub != null) {
               shallowPropagate(subs);
             }
             sub = link.sub;

--- a/lib/src/system.dart
+++ b/lib/src/system.dart
@@ -460,17 +460,15 @@ abstract class ReactiveSystem {
       if ((sub.flags & ReactiveFlags.dirty) != ReactiveFlags.none) {
         dirty = true;
       } else if ((flags & 17 /*(ReactiveFlags.mutable | ReactiveFlags.dirty)*/ ) == 17 /*(ReactiveFlags.mutable | ReactiveFlags.dirty)*/) {
+        final subs = dep.subs;
         if (update(dep)) {
-          final subs = dep.subs!;
-          if (subs.nextSub != null) {
+          if (subs != null && subs.nextSub != null) {
             shallowPropagate(subs);
           }
           dirty = true;
         }
       } else if ((flags & 33 /*(ReactiveFlags.mutable | ReactiveFlags.pending)*/ ) == 33 /*(ReactiveFlags.mutable | ReactiveFlags.pending)*/) {
-        if (link.nextSub != null|| link.prevSub != null) {// dart format on
-          stack = Stack(value: link, prev: stack);
-        }
+        stack = Stack(value: link, prev: stack);
         link = dep.deps!;
         sub = dep;
         ++checkDepth;
@@ -486,18 +484,13 @@ abstract class ReactiveSystem {
       }
 
       while ((checkDepth--) > 0) {
-        final firstSub = sub.subs!, hasMultipleSubs = firstSub.nextSub != null;
-
-        if (hasMultipleSubs) {
-          link = stack!.value;
-          stack = stack.prev;
-        } else {
-          link = firstSub;
-        }
+        link = stack!.value;
+        stack = stack.prev;
         if (dirty) {
+          final subs = sub.subs;
           if (update(sub)) {
-            if (hasMultipleSubs) {
-              shallowPropagate(firstSub);
+            if (subs != null && subs.nextSub != null) {
+              shallowPropagate(subs);
             }
             sub = link.sub;
             continue;
@@ -514,7 +507,7 @@ abstract class ReactiveSystem {
         }
       }
 
-      return dirty;
+      return dirty && sub.flags != ReactiveFlags.none;
     } while (true);
   }
 

--- a/test/check_dirty_graph_mutation_test.dart
+++ b/test/check_dirty_graph_mutation_test.dart
@@ -1,0 +1,111 @@
+import 'package:alien_signals/alien_signals.dart';
+import 'package:alien_signals/preset.dart' show getActiveSub;
+import 'package:alien_signals/system.dart' show ReactiveFlags, ReactiveNode;
+import 'package:test/test.dart';
+
+void main() {
+  test('disposing an effect during computed dirty checking is safe', () {
+    final shouldDispose = signal(false);
+    late Effect stop;
+
+    final inner = computed((_) {
+      if (shouldDispose()) stop();
+      return 0;
+    });
+    final outer = computed((_) => inner());
+
+    stop = effect(() {
+      outer();
+    });
+
+    shouldDispose.set(true);
+  });
+
+  test('effect disposed during another update stays detached', () {
+    final source = signal(0);
+    late Effect stopFirst;
+    ReactiveNode? firstNode;
+    int firstRuns = 0;
+    int secondValue = -1;
+    int thirdValue = -1;
+
+    final derived = computed((_) {
+      final value = source();
+      if (value == 1) stopFirst();
+      return value;
+    });
+
+    stopFirst = effect(() {
+      firstNode ??= getActiveSub();
+      derived();
+      firstRuns++;
+    });
+    effect(() {
+      secondValue = derived();
+    });
+    effect(() {
+      thirdValue = derived();
+    });
+
+    expect(firstRuns, 1);
+    expect(secondValue, 0);
+    expect(thirdValue, 0);
+
+    source.set(1);
+    expect(firstRuns, 1);
+    expect(secondValue, 1);
+    expect(thirdValue, 1);
+    expect(firstNode!.deps, isNull);
+    expect(firstNode!.flags & ReactiveFlags.watching, ReactiveFlags.none);
+
+    source.set(2);
+    expect(firstRuns, 1);
+    expect(secondValue, 2);
+    expect(thirdValue, 2);
+  });
+
+  test('disposing an effect scope during computed update is safe', () {
+    final shouldDispose = signal(false);
+    late EffectScope stopScope;
+
+    final inner = computed((_) {
+      if (shouldDispose()) stopScope();
+      return 0;
+    });
+    final outer = computed((_) => inner());
+
+    stopScope = effectScope(() {
+      effect(() {
+        outer();
+      });
+    });
+
+    shouldDispose.set(true);
+  });
+
+  test('dirty checking handles a dependency that loses subscribers', () {
+    final source = signal(0);
+    late Effect stop;
+
+    final stable = computed((_) {
+      source();
+      return 0;
+    });
+    final disposing = computed((_) {
+      final value = source();
+      if (value != 0) stop();
+      return value;
+    });
+    final combined = computed((_) {
+      stable();
+      disposing();
+      return 0;
+    });
+
+    stop = effect(() {
+      combined();
+    });
+
+    source.set(1);
+  });
+}

--- a/test/effect_cleanup_test.dart
+++ b/test/effect_cleanup_test.dart
@@ -98,6 +98,151 @@ void main() {
     expect(runs, 1);
   });
 
+  test('nested effect cleanup runs before parent cleanup on re-run', () {
+    final source = signal(0);
+    final log = <String>[];
+
+    effect(() {
+      source();
+      log.add('outer run');
+      effect(() {
+        log.add('inner run');
+        return () {
+          log.add('inner cleanup');
+        };
+      });
+      return () {
+        log.add('outer cleanup');
+      };
+    });
+
+    expect(log, ['outer run', 'inner run']);
+
+    log.clear();
+    source.set(1);
+    expect(log, ['inner cleanup', 'outer cleanup', 'outer run', 'inner run']);
+  });
+
+  test('effect disposal cleans children in reverse dependency order', () {
+    final log = <String>[];
+
+    final stop = effect(() {
+      effect(() {
+        effect(() {
+          return () {
+            log.add('grandchild cleanup');
+          };
+        });
+        return () {
+          log.add('child cleanup');
+        };
+      });
+      effect(() {
+        return () {
+          log.add('sibling cleanup');
+        };
+      });
+      return () {
+        log.add('outer cleanup');
+      };
+    });
+
+    stop();
+    expect(log, [
+      'sibling cleanup',
+      'grandchild cleanup',
+      'child cleanup',
+      'outer cleanup',
+    ]);
+  });
+
+  test(
+    'computed refresh disposes child effects before running getter again',
+    () {
+      final source = signal(0);
+      final log = <String>[];
+
+      final value = computed((previous) {
+        log.add('computed run');
+        effect(() {
+          log.add('inner run');
+          return () {
+            log.add('inner cleanup');
+          };
+        });
+        return source();
+      });
+
+      effect(() {
+        value();
+      });
+
+      expect(log, ['computed run', 'inner run']);
+
+      log.clear();
+      source.set(1);
+      expect(log, ['inner cleanup', 'computed run', 'inner run']);
+    },
+  );
+
+  test('computed disposal cleans child effects in reverse order', () {
+    final log = <String>[];
+
+    final value = computed((previous) {
+      effect(() {
+        return () {
+          log.add('first cleanup');
+        };
+      });
+      effect(() {
+        return () {
+          log.add('second cleanup');
+        };
+      });
+      effect(() {
+        return () {
+          log.add('third cleanup');
+        };
+      });
+      return 0;
+    });
+
+    final stop = effect(() {
+      value();
+    });
+
+    log.clear();
+    stop();
+    expect(log, ['third cleanup', 'second cleanup', 'first cleanup']);
+  });
+
+  test('outer cleanup order survives an inner-only re-run', () {
+    final outerSource = signal(0);
+    final innerSource = signal(0);
+    final log = <String>[];
+
+    effect(() {
+      outerSource();
+      log.add('outer run');
+      effect(() {
+        innerSource();
+        log.add('inner run');
+        return () {
+          log.add('inner cleanup');
+        };
+      });
+      return () {
+        log.add('outer cleanup');
+      };
+    });
+
+    innerSource.set(1);
+    log.clear();
+
+    outerSource.set(1);
+    expect(log, ['inner cleanup', 'outer cleanup', 'outer run', 'inner run']);
+  });
+
   test(
     'effect should unsubscribe from stale dependencies when branches change',
     () {

--- a/test/effect_cleanup_test.dart
+++ b/test/effect_cleanup_test.dart
@@ -52,6 +52,30 @@ void main() {
     expect(cleanups, 1);
   });
 
+  test('effect cleanup reads are not tracked on dispose', () {
+    final cleanupSource = signal(0);
+    int outerRuns = 0;
+    int cleanups = 0;
+
+    effect(() {
+      outerRuns++;
+      final stop = effect(() {
+        return () {
+          cleanupSource();
+          cleanups++;
+        };
+      });
+      stop();
+    });
+
+    expect(outerRuns, 1);
+    expect(cleanups, 1);
+
+    cleanupSource.set(1);
+    expect(outerRuns, 1);
+    expect(cleanups, 1);
+  });
+
   test('effect cleanup can stop the effect before re-run', () {
     final source = signal(0);
     late Effect stop;

--- a/test/effect_cleanup_test.dart
+++ b/test/effect_cleanup_test.dart
@@ -2,6 +2,78 @@ import 'package:alien_signals/alien_signals.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test('effect cleanup runs before re-run and on dispose', () {
+    final source = signal(0);
+    final log = <String>[];
+
+    final stop = effect(() {
+      final value = source();
+      log.add('run $value');
+      return () {
+        log.add('cleanup $value');
+      };
+    });
+
+    expect(log, ['run 0']);
+
+    source.set(1);
+    expect(log, ['run 0', 'cleanup 0', 'run 1']);
+
+    stop();
+    expect(log, ['run 0', 'cleanup 0', 'run 1', 'cleanup 1']);
+
+    source.set(2);
+    expect(log, ['run 0', 'cleanup 0', 'run 1', 'cleanup 1']);
+  });
+
+  test('effect cleanup reads are not tracked before re-run', () {
+    final source = signal(0);
+    final cleanupSource = signal(0);
+    int runs = 0;
+    int cleanups = 0;
+
+    effect(() {
+      source();
+      runs++;
+      return () {
+        cleanupSource();
+        cleanups++;
+      };
+    });
+
+    expect(runs, 1);
+
+    source.set(1);
+    expect(runs, 2);
+    expect(cleanups, 1);
+
+    cleanupSource.set(1);
+    expect(runs, 2);
+    expect(cleanups, 1);
+  });
+
+  test('effect cleanup can stop the effect before re-run', () {
+    final source = signal(0);
+    late Effect stop;
+    int runs = 0;
+    int cleanups = 0;
+
+    stop = effect(() {
+      source();
+      runs++;
+      return () {
+        cleanups++;
+        stop();
+      };
+    });
+
+    expect(runs, 1);
+
+    source.set(1);
+    expect(cleanups, 1);
+    expect(runs, 1);
+  });
+
   test(
     'effect should unsubscribe from stale dependencies when branches change',
     () {

--- a/test/effect_scope_test.dart
+++ b/test/effect_scope_test.dart
@@ -65,4 +65,30 @@ void main() {
       expect(triggers, 2);
     },
   );
+
+  test('should propagate computed changes through nested scopes', () {
+    final source = signal(0);
+    final computedValue = computed((_) => source() * 2);
+    int triggers = 0;
+
+    effect(() {
+      triggers++;
+      effectScope(() {
+        effectScope(() {
+          source();
+          computedValue();
+        });
+      });
+    });
+
+    expect(triggers, 1);
+
+    source.set(1);
+    expect(triggers, 2);
+
+    trigger(() {
+      computedValue();
+    });
+    expect(triggers, 3);
+  });
 }

--- a/test/effect_scope_test.dart
+++ b/test/effect_scope_test.dart
@@ -91,4 +91,56 @@ void main() {
     });
     expect(triggers, 3);
   });
+
+  test('scope disposal cleans child effects in reverse dependency order', () {
+    final log = <String>[];
+
+    final stop = effectScope(() {
+      effect(() {
+        return () {
+          log.add('first cleanup');
+        };
+      });
+      effectScope(() {
+        effect(() {
+          return () {
+            log.add('nested cleanup');
+          };
+        });
+      });
+      effect(() {
+        return () {
+          log.add('last cleanup');
+        };
+      });
+    });
+
+    stop();
+    expect(log, ['last cleanup', 'nested cleanup', 'first cleanup']);
+  });
+
+  test('scope nested in effect cleans children before parent cleanup', () {
+    final source = signal(0);
+    final log = <String>[];
+
+    effect(() {
+      source();
+      log.add('outer run');
+      effectScope(() {
+        effect(() {
+          log.add('inner run');
+          return () {
+            log.add('inner cleanup');
+          };
+        });
+      });
+      return () {
+        log.add('outer cleanup');
+      };
+    });
+
+    log.clear();
+    source.set(1);
+    expect(log, ['inner cleanup', 'outer cleanup', 'outer run', 'inner run']);
+  });
 }

--- a/test/effect_teardown_test.dart
+++ b/test/effect_teardown_test.dart
@@ -1,0 +1,83 @@
+import 'package:alien_signals/alien_signals.dart';
+import 'package:alien_signals/preset.dart' show EffectNode, SignalNode;
+import 'package:alien_signals/system.dart' show ReactiveFlags;
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'stopped effect does not subscribe to signals read later in the same run',
+    () {
+      final rerun = signal(0);
+      final readAfterStop = SignalNode(
+        flags: ReactiveFlags.mutable,
+        currentValue: 0,
+        pendingValue: 0,
+      );
+      Effect? stop;
+      EffectNode? node;
+      bool stopDuringRun = false;
+      int runs = 0;
+
+      stop = effect(() {
+        node ??= stop as EffectNode?;
+        runs++;
+        rerun();
+        if (stopDuringRun) {
+          stop!();
+          readAfterStop.get();
+        }
+      });
+
+      expect(runs, 1);
+      expect(readAfterStop.subs, isNull);
+
+      stopDuringRun = true;
+      rerun.set(1);
+
+      expect(runs, 2);
+      expect(node!.flags, ReactiveFlags.none);
+      expect(readAfterStop.subs, isNull);
+    },
+  );
+
+  test('failed effect setup does not leave a live subscription behind', () {
+    final source = signal(0);
+    int runs = 0;
+
+    expect(
+      () => effect(() {
+        runs++;
+        source();
+        throw StateError('setup failed');
+      }),
+      throwsStateError,
+    );
+
+    expect(runs, 1);
+    expect(() => source.set(1), returnsNormally);
+    expect(runs, 1);
+  });
+
+  test(
+    'failed effect scope setup disposes child effects created before throw',
+    () {
+      final source = signal(0);
+      int childRuns = 0;
+
+      expect(
+        () => effectScope(() {
+          effect(() {
+            childRuns++;
+            source();
+          });
+          throw StateError('scope setup failed');
+        }),
+        throwsStateError,
+      );
+
+      expect(childRuns, 1);
+      source.set(1);
+      expect(childRuns, 1);
+    },
+  );
+}

--- a/test/effect_test.dart
+++ b/test/effect_test.dart
@@ -362,6 +362,32 @@ void main() {
     expect(runs, 4);
   });
 
+  test('outer effect should keep responding after inner effect re-runs', () {
+    final outerSource = signal(0);
+    final innerSource = signal(0);
+    int outerRuns = 0;
+    int innerRuns = 0;
+
+    effect(() {
+      outerSource();
+      outerRuns++;
+      effect(() {
+        innerSource();
+        innerRuns++;
+      });
+    });
+
+    expect(outerRuns, 1);
+    expect(innerRuns, 1);
+
+    innerSource.set(1);
+    expect(outerRuns, 1);
+    expect(innerRuns, greaterThanOrEqualTo(2));
+
+    outerSource.set(1);
+    expect(outerRuns, 2);
+  });
+
   test('should support custom recurse effect', () {
     final src = signal(0);
 

--- a/test/effect_test.dart
+++ b/test/effect_test.dart
@@ -335,6 +335,33 @@ void main() {
     expect(triggers2, 1);
   });
 
+  test('should keep propagating computed chain after inner signal writes', () {
+    final source = signal(0);
+    final computedValue = computed((_) => source());
+    int runs = 0;
+
+    effect(() {
+      runs++;
+      if (computedValue() > 0) {
+        source.set(0);
+      }
+    });
+
+    expect(runs, 1);
+
+    source.set(1);
+    expect(source(), 0);
+    expect(runs, 2);
+
+    source.set(2);
+    expect(source(), 0);
+    expect(runs, 3);
+
+    source.set(3);
+    expect(source(), 0);
+    expect(runs, 4);
+  });
+
   test('should support custom recurse effect', () {
     final src = signal(0);
 


### PR DESCRIPTION
## Summary

- Sync Dart behavior with upstream alien-signals v3.2.1 through commit `8734d386d925025d0e99419bd9161c17b112c5ee`.
- Add typed cleanup callback support for `effect()` and run cleanup before re-runs or disposal.
- Fix nested effect/scope disposal order, `effectScope()` propagation, dirty-check graph mutation handling, and inner-write propagation through computed chains.
- Reorganize the 2.3.0 changelog around the user-facing API addition and runtime fixes.

## Validation

- `dart analyze`
- `dart test`

No issue is linked; this PR tracks upstream sync work rather than a repository issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * effect() can return a cleanup callback; effectScope nesting/propagation improved

* **Bug Fixes**
  * Corrected disposal and cleanup ordering for effects/computeds
  * Preserved subscriptions across re-runs; fixed propagation for writes inside effects
  * Made updates resilient to dependency-graph mutations; tightened cleanup timing

* **Documentation**
  * API and guide updated to document generic effect callbacks and cleanup behavior

* **Tests**
  * Added comprehensive tests covering cleanup, teardown, scopes, and mutation cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/medz/alien-signals-dart/pull/37)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->